### PR TITLE
Update details.blade.php

### DIFF
--- a/views/account/details.blade.php
+++ b/views/account/details.blade.php
@@ -1,8 +1,7 @@
 <form class="form-horizontal" action="{{ $form['url'] }}" method="POST">
 
-    {{ csrf_field() }}
-    {{ method_field($form['method']) }}
-    <input type="hidden" name="_method" value="{{ $form['_method'] }}">
+    {!! csrf_field() !!}
+    {!! method_field($form['method']) !!}
 
     <div class="form-group{!! ($errors->has('first_name')) ? ' has-error' : '' !!}">
         <label class="col-md-2 col-sm-3 col-xs-10 control-label" for="first_name">First Name</label>


### PR DESCRIPTION
csrf_ and method_field don't need to be escaped.
`<input name="_method">` is generated by method_field-function:
[Laravel Docs: Routing # Form Method Spoofing](http://laravel.com/docs/5.1/routing#form-method-spoofing)