### PR TITLE
Don't override the default boot() method

### DIFF
--- a/src/Models/Relations/RevisionableTrait.php
+++ b/src/Models/Relations/RevisionableTrait.php
@@ -74,10 +74,8 @@ trait RevisionableTrait
      *
      * @return void
      */
-    public static function boot()
+    public static function bootRevisionableTrait()
     {
-        parent::boot();
-
         static::saving(function ($model) {
             $model->preSave();
         });


### PR DESCRIPTION
The developer may want to override boot, and traits might have conflicting boot methods.  Using Laravel's bootTraitName() naming pattern eliminates this problem and is cleaner.